### PR TITLE
Fixing bug that inserted events weren't properly shown in the agenda list

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="18" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,6 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="18" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -65,7 +65,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18_PREVIEW" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
         jvmTarget = '1.8'

--- a/app/src/main/java/com/andrew/tasky/domain/db/AgendaItemDao.kt
+++ b/app/src/main/java/com/andrew/tasky/domain/db/AgendaItemDao.kt
@@ -1,12 +1,12 @@
 package com.andrew.tasky.domain.db
 
-import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.andrew.tasky.domain.AgendaItem
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface AgendaItemDao {
@@ -15,7 +15,7 @@ interface AgendaItemDao {
     suspend fun upsert(agendaItem: AgendaItem): Long
 
     @Query("SELECT * FROM agendaItems")
-    fun getAllAgendaItems(): LiveData<List<AgendaItem>>
+    fun getAllAgendaItems(): Flow<List<AgendaItem>>
 
     @Delete
     suspend fun deleteAgendaItem(agendaItem: AgendaItem)

--- a/app/src/main/java/com/andrew/tasky/domain/repository/AgendaItemRepository.kt
+++ b/app/src/main/java/com/andrew/tasky/domain/repository/AgendaItemRepository.kt
@@ -1,9 +1,9 @@
 package com.andrew.tasky.domain.repository
 
-import androidx.lifecycle.LiveData
 import com.andrew.tasky.domain.AgendaItem
 import com.andrew.tasky.domain.db.AgendaItemDatabase
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 class AgendaItemRepository @Inject constructor(
     private val db: AgendaItemDatabase
@@ -12,7 +12,7 @@ class AgendaItemRepository @Inject constructor(
         db.getAgendaItemDao().upsert(agendaItem)
     }
 
-    fun getAgendaItems(): LiveData<List<AgendaItem>> {
+    fun getAgendaItems(): Flow<List<AgendaItem>> {
         return db.getAgendaItemDao().getAllAgendaItems()
     }
 

--- a/app/src/main/java/com/andrew/tasky/presentation/adapters/AgendaItemAdapter.kt
+++ b/app/src/main/java/com/andrew/tasky/presentation/adapters/AgendaItemAdapter.kt
@@ -5,6 +5,8 @@ import android.graphics.Paint
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.PopupMenu
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.andrew.tasky.R
 import com.andrew.tasky.databinding.ItemAgendaBinding
@@ -14,9 +16,18 @@ import com.andrew.tasky.util.AgendaItemType
 import java.time.format.DateTimeFormatter
 
 class AgendaItemAdapter(
-    private var agendaItems: List<AgendaItem>,
     private val onAgendaItemOptionClick: (AgendaItem, AgendaItemMenuOption) -> Unit
-) : RecyclerView.Adapter<AgendaItemAdapter.AgendaItemViewHolder>() {
+) : ListAdapter<AgendaItem, AgendaItemAdapter.AgendaItemViewHolder>(Companion) {
+
+    companion object : DiffUtil.ItemCallback<AgendaItem>() {
+        override fun areItemsTheSame(oldItem: AgendaItem, newItem: AgendaItem): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: AgendaItem, newItem: AgendaItem): Boolean {
+            return oldItem == newItem
+        }
+    }
 
     inner class AgendaItemViewHolder(val binding: ItemAgendaBinding) :
         RecyclerView.ViewHolder(binding.root)
@@ -29,23 +40,23 @@ class AgendaItemAdapter(
 
     override fun onBindViewHolder(holder: AgendaItemViewHolder, position: Int) {
         holder.binding.apply {
-            agendaItemTitle.text = agendaItems[position].title
-            agendaItemDescription.text = agendaItems[position].description
+            agendaItemTitle.text = currentList[position].title
+            agendaItemDescription.text = currentList[position].description
             agendaItemDate.text = (
-                agendaItems[position].startDateAndTime
+                currentList[position].startDateAndTime
                     .format(DateTimeFormatter.ofPattern("MMM d, HH:mm")) +
                     (
-                        agendaItems[position].endDateAndTime
+                        currentList[position].endDateAndTime
                             ?.format(DateTimeFormatter.ofPattern(" - MMM d, HH:mm")) ?: ""
                         )
                 )
 
             doneButton.setOnClickListener {
-                agendaItems[position].isDone = true
+                currentList[position].isDone = true
             }
 
             agendaItemCard.setOnClickListener {
-                onAgendaItemOptionClick(agendaItems[position], AgendaItemMenuOption.OPEN)
+                onAgendaItemOptionClick(currentList[position], AgendaItemMenuOption.OPEN)
             }
 
             optionsButton.setOnClickListener { view ->
@@ -55,17 +66,17 @@ class AgendaItemAdapter(
                     when (menuItem.itemId) {
                         R.id.open -> {
                             val actionOption = AgendaItemMenuOption.OPEN
-                            onAgendaItemOptionClick(agendaItems[position], actionOption)
+                            onAgendaItemOptionClick(currentList[position], actionOption)
                             true
                         }
                         R.id.edit -> {
                             val actionOption = AgendaItemMenuOption.EDIT
-                            onAgendaItemOptionClick(agendaItems[position], actionOption)
+                            onAgendaItemOptionClick(currentList[position], actionOption)
                             true
                         }
                         R.id.delete -> {
                             val actionOption = AgendaItemMenuOption.DELETE
-                            onAgendaItemOptionClick(agendaItems[position], actionOption)
+                            onAgendaItemOptionClick(currentList[position], actionOption)
                             true
                         }
                         else -> true
@@ -74,7 +85,7 @@ class AgendaItemAdapter(
                 popupMenu.show()
             }
 
-            if (agendaItems[position].isDone) {
+            if (currentList[position].isDone) {
                 doneButton.setImageResource(R.drawable.task_done_circle)
                 agendaItemTitle.paintFlags = Paint.STRIKE_THRU_TEXT_FLAG
             } else {
@@ -82,7 +93,7 @@ class AgendaItemAdapter(
                 agendaItemTitle.paintFlags = Paint.ANTI_ALIAS_FLAG
             }
 
-            when (agendaItems[position].type) {
+            when (currentList[position].type) {
                 AgendaItemType.TASK -> {
                     agendaItemCard.setCardBackgroundColor(Color.parseColor("#259f70"))
                     doneButton.setColorFilter(Color.parseColor("#FFeeeeee"))
@@ -99,9 +110,5 @@ class AgendaItemAdapter(
                 )
             }
         }
-    }
-
-    override fun getItemCount(): Int {
-        return agendaItems.size
     }
 }

--- a/app/src/main/java/com/andrew/tasky/presentation/agenda/AgendaFragment.kt
+++ b/app/src/main/java/com/andrew/tasky/presentation/agenda/AgendaFragment.kt
@@ -29,6 +29,8 @@ class AgendaFragment : Fragment(R.layout.fragment_agenda) {
     private var currentDateAndTime: LocalDateTime = LocalDateTime.now()
     private var currentDate = currentDateAndTime.toLocalDate()
 
+    private lateinit var agendaAdapter: AgendaItemAdapter
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -38,6 +40,7 @@ class AgendaFragment : Fragment(R.layout.fragment_agenda) {
         subscribeToObservables()
         setOnClickListeners()
         setupCurrentMonthTextView()
+        setupAgendaItemListRecyclerView()
     }
 
     private fun subscribeToObservables() {
@@ -46,7 +49,6 @@ class AgendaFragment : Fragment(R.layout.fragment_agenda) {
         )
         collectLatestLifecycleFlow(viewModel.dateSelected) { dateSelected ->
             setupCurrentDateSelectedTextView(dateSelected)
-            setupAgendaItemListRecyclerView(dateSelected)
 
             val adapter = MiniCalendarAdapter(
                 startDate = currentDate,
@@ -55,6 +57,9 @@ class AgendaFragment : Fragment(R.layout.fragment_agenda) {
                 onHolderClick = { dateClicked -> viewModel.setDateSelected(dateClicked) }
             )
             fragmentAgendaBinding.miniCalendar.adapter = adapter
+        }
+        collectLatestLifecycleFlow(viewModel.agendaItems) { items ->
+            agendaAdapter.submitList(items)
         }
     }
 
@@ -160,16 +165,13 @@ class AgendaFragment : Fragment(R.layout.fragment_agenda) {
         }
     }
 
-    private fun setupAgendaItemListRecyclerView(dateSelected: LocalDate) {
-        val sortedAgendaItems = viewModel.sortByDateSelected(dateSelected)
-
-        val adapter = AgendaItemAdapter(
-            agendaItems = sortedAgendaItems,
+    private fun setupAgendaItemListRecyclerView() {
+        agendaAdapter = AgendaItemAdapter(
             onAgendaItemOptionClick = { agendaItem, agendaItemActionOptions ->
                 agendaItemOptions(agendaItem, agendaItemActionOptions)
             }
         )
-        fragmentAgendaBinding.agendaItemRecyclerView.adapter = adapter
+        fragmentAgendaBinding.agendaItemRecyclerView.adapter = agendaAdapter
         fragmentAgendaBinding.agendaItemRecyclerView.layoutManager =
             LinearLayoutManager(requireContext())
     }

--- a/app/src/main/java/com/andrew/tasky/presentation/agenda/AgendaViewModel.kt
+++ b/app/src/main/java/com/andrew/tasky/presentation/agenda/AgendaViewModel.kt
@@ -7,8 +7,7 @@ import com.andrew.tasky.domain.repository.AgendaItemRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.time.LocalDate
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -18,16 +17,20 @@ class AgendaViewModel@Inject constructor(
 
     private val _dateSelected = MutableStateFlow(LocalDate.now())
     val dateSelected = _dateSelected.asStateFlow()
+
+    // The combine block will automatically be called every time either agendaItems or the selected
+    // date is changed and therefore properly recalculate the list as needed.
+    val agendaItems = repository
+        .getAgendaItems()
+        .combine(dateSelected) { items, selectedDate ->
+            items
+                .filter { it.startDateAndTime.toLocalDate() == selectedDate }
+                .sortedBy { it.startDateAndTime }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
     fun setDateSelected(dateUserSelected: LocalDate) {
         _dateSelected.value = dateUserSelected
-    }
-
-    fun sortByDateSelected(dateSelected: LocalDate): List<AgendaItem> {
-        return repository.getAgendaItems().value?.sortedBy { agendaItem ->
-            agendaItem.startDateAndTime
-        }?.filter {
-            it.startDateAndTime.toLocalDate() == dateSelected
-        } ?: emptyList<AgendaItem>()
     }
 
     fun deleteAgendaItem(agendaItem: AgendaItem) {

--- a/app/src/main/java/com/andrew/tasky/presentation/event_detail/EventDetailViewModel.kt
+++ b/app/src/main/java/com/andrew/tasky/presentation/event_detail/EventDetailViewModel.kt
@@ -12,8 +12,10 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import javax.inject.Inject
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltViewModel
 class EventDetailViewModel @Inject constructor(
@@ -152,8 +154,14 @@ class EventDetailViewModel @Inject constructor(
             photos = photos.value,
             attendees = attendees.value
         )
+        // viewModelScope gets cancelled as soon as the Fragment is popped from the backstack,
+        // so if you pop it right after inserting an element, this coroutine will be cancelled
+        // before it can finish inserting the element. With NonCancellable we make sure it's not
+        // going to be cancelled.
         viewModelScope.launch {
-            repository.upsert(agendaItem)
+            withContext(NonCancellable) {
+                repository.upsert(agendaItem)
+            }
         }
     }
 


### PR DESCRIPTION
The main issue was that you again setup your adapter once, but never updated the list. Your way it just displayed the initial item list. I also changed the return type of your agenda items to a Flow, so it allows us to use reactive combiners, so that the `agendaItem` list gets updated every time there's a change in either the items or the selected date. Then, the UI observes that list and updates the RecyclerView where I introduced DiffUtil.

Also I noticed that your package structure is a bit wrong, since you put a lot of data related stuff in domain. Implementation details such as which DB you're using, how you get data etc belong in a separate data layer. Domain should be fully isolated from that, so that if such requirements change (and you use a different DB framework for example), only data will change, but not domain and presentation.
Also, your domain/di package should be a root package, since DI is not domain related.